### PR TITLE
Reduce GamificationTrait

### DIFF
--- a/app/Level.php
+++ b/app/Level.php
@@ -24,11 +24,11 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 /**
  * Model that represents a badge.
  *
- * @property int     $id                    Object unique id.
- * @property string  $name                  Name of the level..
- * @property int $required_points       How many points do you need to achieve it.
- * @property string  image_url              URL of the level's image
- * @property bool active                 Is this level enabled?
+ * @property int    $id                    Object unique id.
+ * @property string $name                  Name of the level..
+ * @property int    $required_points       How many points do you need to achieve it.
+ * @property string image_url              URL of the level's image
+ * @property bool   active                 Is this level enabled?
  */
 class Level extends Model
 {
@@ -81,5 +81,43 @@ class Level extends Model
     public function getImageURL(): string
     {
         return asset('images/missing_level.png');
+    }
+
+    /**
+     * Get current Level (object) for the given experience.
+     *
+     * @param int $experience
+     *
+     * @return \Gamify\Level
+     */
+    public static function fromExperience(int $experience)
+    {
+        return Level::where('required_points', '<=', $experience)->orderBy('required_points')->first();
+    }
+
+    /**
+     * Return the next Level (object) for the given experience.
+     *
+     * @param int $experience
+     *
+     * @return \Gamify\Level
+     */
+    public static function nextFromExperience(int $experience)
+    {
+        return Level::where('required_points', '>', $experience)->orderBy('required_points')->first();
+    }
+
+    /**
+     * Returns how many Experience Points until next Level.
+     *
+     * @param int $experience
+     *
+     * @return int
+     */
+    public static function experienceUntilNextLevel(int $experience): int
+    {
+        $nextLevel = self::nextFromExperience($experience);
+
+        return (($nextLevel->required_points - $experience) > 0) ?: 0;
     }
 }

--- a/app/Level.php
+++ b/app/Level.php
@@ -92,7 +92,7 @@ class Level extends Model
      */
     public static function fromExperience(int $experience)
     {
-        return Level::where('required_points', '<=', $experience)->orderBy('required_points')->first();
+        return self::where('required_points', '<=', $experience)->orderBy('required_points')->first();
     }
 
     /**
@@ -104,7 +104,7 @@ class Level extends Model
      */
     public static function nextFromExperience(int $experience)
     {
-        return Level::where('required_points', '>', $experience)->orderBy('required_points')->first();
+        return self::where('required_points', '>', $experience)->orderBy('required_points')->first();
     }
 
     /**

--- a/app/Traits/GamificationTrait.php
+++ b/app/Traits/GamificationTrait.php
@@ -28,79 +28,17 @@ namespace Gamify\Traits;
 use Gamify\Badge;
 use Gamify\Level;
 use Gamify\Question;
-use Illuminate\Database\Eloquent\Relations\Relation;
 
 trait GamificationTrait
 {
-    /**
-     * These are the User's answered Questions.
-     *
-     * It uses a pivot table with these values:
-     *
-     * points: int - how many points was obtained
-     * answers: string - which answers was supplied
-     *
-     * @return Relation
-     */
-    public function answeredQuestions()
-    {
-        return $this->belongsToMany('Gamify\Question', 'users_questions', 'user_id', 'question_id')
-            ->withPivot('points', 'answers');
-    }
-
-    /**
-     * These are the User's Badges relationship.
-     *
-     * It uses a pivot table with these values:
-     *
-     * amount: int - how many actions has completed
-     * completed: bool - true if User's has own this badge
-     * completed_on: Datetime - where it was completed
-     *
-     * @return Relation
-     */
-    public function badges()
-    {
-        return $this->belongsToMany('Gamify\Badge', 'users_badges', 'user_id', 'badge_id')
-            ->withPivot('repetitions', 'completed', 'completed_on');
-    }
-
-    /**
-     * These are the User's Points relationship.
-     *
-     * Results are grouped by user_is and it selects the sum of all points
-     *
-     * @return Relation
-     */
-    public function points()
-    {
-        return $this->hasMany('Gamify\Point')
-            ->selectRaw('sum(points) as sum, user_id')
-            ->groupBy('user_id');
-    }
-
-    /**
-     * Get current Level (object) for this user.
-     *
-     * @return Level
-     */
-    public function getLevel()
-    {
-        $experience = $this->getExperiencePoints();
-
-        return Level::where('required_points', '<=', $experience)->orderBy('required_points')->first();
-    }
-
     /**
      * Get current Level name for this user.
      *
      * @return string
      */
-    public function getLevelName()
+    public function getCurrentLevelName()
     {
-        $level = $this->getLevel();
-
-        return $level->name;
+        return Level::fromExperience($this->getExperiencePoints())->name;
     }
 
     /**
@@ -125,9 +63,7 @@ trait GamificationTrait
      */
     public function getNextLevel()
     {
-        $experience = $this->getExperiencePoints();
-
-        return Level::where('required_points', '>', $experience)->orderBy('required_points')->first();
+        return Level::nextFromExperience($this->getExperiencePoints());
     }
 
     /**
@@ -157,16 +93,6 @@ trait GamificationTrait
     }
 
     /**
-     * Get current Experience points for this user.
-     *
-     * @return int
-     */
-    public function getExperiencePoints()
-    {
-        return $this->points()->sum('points');
-    }
-
-    /**
      * Checks if user has the given Badge.
      *
      * @param Badge $badge
@@ -178,16 +104,6 @@ trait GamificationTrait
         $userBadge = $this->badges()->find($badge->id);
 
         return $userBadge->pivot->completed;
-    }
-
-    /**
-     * Returns a Collection of completed Badges for this user.
-     *
-     * @return mixed
-     */
-    public function getCompletedBadges()
-    {
-        return $this->badges()->wherePivot('completed', true)->get();
     }
 
     public function getPendingQuestions()

--- a/resources/views/admin/partials/header.blade.php
+++ b/resources/views/admin/partials/header.blade.php
@@ -40,7 +40,7 @@
                             <img src="{{ Auth()->user()->profile->getAvatarURL() }}" class="img-circle"
                                  alt="{{ trans('user/profile.avatar') }}"/>
                             <p>
-                                {{ Auth()->user()->name }} - {{ Auth()->user()->getLevelName() }}
+                                {{ Auth()->user()->name }} - {{ Auth()->user()->getCurrentLevelName() }}
                                 <small>Member since {{ date("M Y", strtotime(Auth()->user()->created_at)) }}</small>
                             </p>
                         </li>

--- a/resources/views/dashboard/_ranking.blade.php
+++ b/resources/views/dashboard/_ranking.blade.php
@@ -11,7 +11,7 @@
         <tr>
             <td>{{ $index+1 }}</td>
             <td><a href="{{ route('profiles.show', $userInRank->username) }}">{{ $userInRank->name }}</a></td>
-            <td>{{ $userInRank->getLevelName() }}</td>
+            <td>{{ $userInRank->getCurrentLevelName() }}</td>
             <td>{{ $userInRank->getExperiencePoints() }}</td>
         </tr>
     @endforeach

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -43,7 +43,7 @@
                                 <img src="{{ Auth()->user()->profile->getAvatarURL() }}" class="img-circle"
                                      alt="{{ trans('user/profile.avatar') }}"/>
                                 <p>
-                                    {{ Auth()->user()->name }} - {{ Auth()->user()->getLevelName() }}
+                                    {{ Auth()->user()->name }} - {{ Auth()->user()->getCurrentLevelName() }}
                                     <small>Member since {{ date("M Y", strtotime(Auth()->user()->created_at)) }}</small>
                                 </p>
                             </li>

--- a/resources/views/profile/_about_me.blade.php
+++ b/resources/views/profile/_about_me.blade.php
@@ -101,7 +101,7 @@
             <tbody>
             <tr>
                 <td>{{ trans('user/profile.level') }}:</td>
-                <td>{{ $user->getLevelName() }}</td>
+                <td>{{ $user->getCurrentLevelName() }}</td>
             </tr>
             <tr>
                 <td>{{ trans('user/profile.rank') }}:</td>

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -35,7 +35,7 @@
 
                     <h3 class="profile-username text-center">{{ $user->name }}</h3>
 
-                    <p class="text-muted text-center">{{ $user->getLevelName() }}</p>
+                    <p class="text-muted text-center">{{ $user->getCurrentLevelName() }}</p>
 
                     <ul class="list-group list-group-unbordered">
                         <li class="list-group-item">

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -19,6 +19,8 @@
 namespace Tests\Unit;
 
 use Gamify\User;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
@@ -132,5 +134,26 @@ class UserTest extends ModelTestCase
         $m = new User();
         $r = $m->profile();
         $this->assertInstanceOf(HasOne::class, $r);
+    }
+
+    public function test_answeredQuestions_relation()
+    {
+        $m = new User();
+        $r = $m->answeredQuestions();
+        $this->assertInstanceOf(BelongsToMany::class, $r);
+    }
+
+    public function test_badges_relation()
+    {
+        $m = new User();
+        $r = $m->badges();
+        $this->assertInstanceOf(BelongsToMany::class, $r);
+    }
+
+    public function test_points_relation()
+    {
+        $m = new User();
+        $r = $m->points();
+        $this->assertInstanceOf(HasMany::class, $r);
     }
 }


### PR DESCRIPTION
`GamificationTrait` was a bunch of methods that were not defined in the proper place. We were using a Trait, but it was not proper use, because this Trait was only used in one place.

Moving methods to the right classes, makes this Trait useless.